### PR TITLE
Rebuild 5.2.0 against libarchive 3.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     folder: tessdata_fast
 
 build:
-  number: 2
+  number: 3
   # Currently tesseract hasn't the Windows support because it uses the third-party
   # software for compiling (SW - Software Network client), see https://tesseract-ocr.github.io/tessdoc/Compiling.html#windows,
   # or the installers of the Mannheim University Library (UB Mannheim), see https://github.com/UB-Mannheim/tesseract/wiki
@@ -35,7 +35,7 @@ requirements:
     - pkg-config
   host:
     - leptonica >=1.74.2
-    - libarchive 3.7.7
+    - libarchive 3.8
   run:
     - _openmp_mutex  # [linux]
 


### PR DESCRIPTION
tesseract 5.2.0

**Destination channel:**  defaults

### Links

- [PKG-9569](https://anaconda.atlassian.net/browse/PKG-9569) 
- [Upstream repository](https://github.com/tesseract-ocr/tesseract/tree/5.2.0)


### Explanation of changes:

- Rebuild against libarchive 3.8


[PKG-9569]: https://anaconda.atlassian.net/browse/PKG-9569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ