### PR TITLE
PKG-13568: rebuild tesseract for linux-64 and linux-aarch64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     folder: tessdata_fast
 
 build:
-  number: 3
+  number: 4
   # Currently tesseract hasn't the Windows support because it uses the third-party
   # software for compiling (SW - Software Network client), see https://tesseract-ocr.github.io/tessdoc/Compiling.html#windows,
   # or the installers of the Mannheim University Library (UB Mannheim), see https://github.com/UB-Mannheim/tesseract/wiki


### PR DESCRIPTION
tesseract 5.2.0

**Destination channel:** defaults

### Links

- [PKG-13568](https://anaconda.atlassian.net/browse/PKG-13568)
- [Upstream repository](https://github.com/tesseract-ocr/tesseract)

### Explanation of changes:

- Bump build number to 4 to release tesseract on linux-64 and linux-aarch64
- Currently only osx-arm64 builds are in pkgs/main
- Blocker for pytesseract (PKG-13157) which requires tesseract as a run dep
- No recipe changes — host deps (leptonica, libarchive) are already available on all linux platforms

[PKG-13568]: https://anaconda.atlassian.net/browse/PKG-13568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ