### PR TITLE
Switch to libgomp

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - build

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - build

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     folder: tessdata_fast
 
 build:
-  number: 4
+  number: 5
   # Currently tesseract hasn't the Windows support because it uses the third-party
   # software for compiling (SW - Software Network client), see https://tesseract-ocr.github.io/tessdoc/Compiling.html#windows,
   # or the installers of the Mannheim University Library (UB Mannheim), see https://github.com/UB-Mannheim/tesseract/wiki
@@ -36,8 +36,9 @@ requirements:
   host:
     - leptonica >=1.74.2
     - libarchive 3.8
+    - libgomp  # [linux]
   run:
-    - _openmp_mutex  # [linux]
+    - libgomp # [linux]
 
 test:
   files:


### PR DESCRIPTION
tesseract openmp rebuild

**Destination channel:** defaults

### Links

- [PKG-14742](https://anaconda.atlassian.net/browse/PKG-14742) 


### Explanation of changes:

- Use libgomp instead of _openmp_mutex that is now included by the openmp implementations. 


[PKG-14742]: https://anaconda.atlassian.net/browse/PKG-14742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ