### PR TITLE
[PKG-13890] Enable Windows build for tesseract 5.5.2

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,13 +5,15 @@ cd tesseract
 if errorlevel 1 exit /b 1
 
 :: Isolate the build.
-mkdir Build-%PKG_NAME%
-cd Build-%PKG_NAME%
+mkdir build
+cd build
 if errorlevel 1 exit /b 1
 
-:: Generate the build files.
+:: Generate the build files. Ninja + MSVC, matching upstream's cmake-win64.yml
+:: and the conda-forge recipe. SW_BUILD=OFF drops the old Software Network
+:: client dependency that used to block the Windows build (removed upstream in 5.5.x).
 echo "Generating the build files..."
-cmake -G "NMake Makefiles" ^
+cmake -G "Ninja" ^
     %CMAKE_ARGS% ^
     -D CMAKE_BUILD_TYPE=Release ^
     -D CMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
@@ -19,27 +21,36 @@ cmake -G "NMake Makefiles" ^
     -D CMAKE_LIBRARY_PATH=%LIBRARY_LIB% ^
     -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
     -D Leptonica_DIR=%LIBRARY_PREFIX% ^
-    :: The real place where leptonica headers are:
-    ::-D Leptonica_INCLUDE_DIRS=%LIBRARY_PREFIX%\include\leptonica ^
     -D SW_BUILD=OFF ^
     -D BUILD_TRAINING_TOOLS=OFF ^
     -D BUILD_SHARED_LIBS=ON ^
-    -D CMAKE_MODULE_LINKER_FLAGS=-whole-archive ^
     ..
 if errorlevel 1 exit 1
 
 cmake --build . --config Release
 if errorlevel 1 exit 1
 
-cmake --build . --config Release --target install 
+cmake --build . --config Release --target install
 if errorlevel 1 exit 1
 
-:: Make copies of the .lib file without the embedded version number
-copy %LIBRARY_LIB%\tesseract41.lib %LIBRARY_LIB%\tesseract.lib
+:: Make a copy of the import lib without the embedded version number so
+:: downstream consumers can link plain -ltesseract. Upstream names the
+:: Windows lib tesseract<MAJOR><MINOR> (CMakeLists OUTPUT_NAME), i.e.
+:: tesseract55 for 5.5.x -- NOT tesseract41 (that was the 4.1 name).
+copy %LIBRARY_LIB%\tesseract55.lib %LIBRARY_LIB%\tesseract.lib
+if errorlevel 1 exit /b 1
 
-:: Copy tessdata to shared directory
+:: Copy tessdata to the shared directory that TESSDATA_PREFIX points at
+:: (see activate.bat: %CONDA_PREFIX%\share\tessdata).
 mkdir %PREFIX%\share\tessdata
 copy ..\..\tessdata_fast\*.traineddata %PREFIX%\share\tessdata
+if errorlevel 1 exit /b 1
+
+:: The install lands under %LIBRARY_PREFIX% (= %PREFIX%\Library), so the
+:: installed tessdata configs need to move across the Library split to where
+:: TESSDATA_PREFIX expects them.
+move %LIBRARY_PREFIX%\share\tessdata\configs %PREFIX%\share\tessdata
+if errorlevel 1 exit /b 1
 
 setlocal EnableDelayedExpansion
 :: Copy the [de]activate scripts to %PREFIX%\etc\conda\[de]activate.d.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,10 +15,9 @@ source:
 
 build:
   number: 0
-  # Windows support not yet implemented. Upstream dropped the SW dependency in 5.5.x
-  # and now builds with cmake+Ninja+MSVC (SW_BUILD=OFF). Windows is feasible but
-  # requires verifying all deps are available in the channel. Tracked as a follow-up.
-  skip: true  # [win]
+  # Windows builds with cmake + Ninja + MSVC (SW_BUILD=OFF). Upstream dropped the
+  # old Software Network (SW) client dependency in 5.5.x, which was the historical
+  # blocker. See recipe/bld.bat. (PKG-13890 win enablement; unblocks PKG-13803.)
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x.x') }}
 
@@ -30,6 +29,7 @@ requirements:
     - autoconf  # [not win]
     - automake  # [not win]
     - cmake >=3.30  # [win]  # upstream bumped cmake requirement in 5.3+
+    - ninja  # [win]
     - libtool  # [not win]
     # make is needed for bootstrapping makefile fragments for automatic dependency tracking
     - make  # [not win]
@@ -42,6 +42,17 @@ requirements:
     # openmp changes to gcc14 ... [then we can] put it in the cbc or use the
     # c_compiler_version jinja, but that's not available yet.
     - libgomp  # [linux] # analint: host_section_needs_exact_pinnings
+    # Imaging deps are pulled in transitively by leptonica, but list them
+    # explicitly on Windows so they're present in the host link environment
+    # (mirrors the conda-forge recipe). libjpeg-turbo is what our channel's
+    # leptonica links against on win-64.
+    - giflib  # [win]
+    - libjpeg-turbo  # [win]
+    - libpng  # [win]
+    - libtiff  # [win]
+    - libwebp  # [win]
+    - openjpeg  # [win]
+    - zlib  # [win]
   run:
     - libgomp  # [linux]
 
@@ -55,7 +66,8 @@ test:
     - tesseract --list-langs
     # Smoke test: eng-only OCR, just verify the binary runs end-to-end.
     - tesseract eurotext.tif outputbase -l eng
-    - cat outputbase.txt
+    - cat outputbase.txt   # [not win]
+    - type outputbase.txt  # [win]
     # Regression test: multi-language OCR against a captured baseline.
     # eurotext.expected.txt was captured from the 5.5.2 build using the
     # same -l flag. Tesseract is deterministic for a given binary +
@@ -64,7 +76,8 @@ test:
     # if OCR genuinely got better, update eurotext.expected.txt and
     # note it in the PR.
     - tesseract eurotext.tif outputbase-multi -l eng+deu+fra+ita+spa+por
-    - diff -u eurotext.expected.txt outputbase-multi.txt
+    - diff -u eurotext.expected.txt outputbase-multi.txt  # [not win]
+    - fc eurotext.expected.txt outputbase-multi.txt       # [win]
 
 about:
   home: https://github.com/tesseract-ocr/tesseract

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     folder: tessdata_fast
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x.x') }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - libtool  # [not win]
     - make  # [not win]
     - cmake >=3.30  # [win]  # upstream bumped cmake requirement in 5.3+
-    - ninja  # [win]
+    - ninja-base  # [win]
     - pkg-config
   host:
     - leptonica {{ leptonica }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,14 +46,8 @@ requirements:
     # openmp changes to gcc14 ... [then we can] put it in the cbc or use the
     # c_compiler_version jinja, but that's not available yet.
     - libgomp  # [linux] # analint: host_section_needs_exact_pinnings
-    # tesseract's CMake links libtiff directly on Windows for multi-page TIFF
-    # support: find_package(TIFF) + target_link_libraries guarded by
-    # `if(HAVE_TIFFIO_H AND WIN32)`. So it's a direct build dep on win (needs
-    # tiffio.h at configure time + the import lib at link time), not just a
-    # transitive leptonica dep. The other imaging codecs (png, jpeg, webp,
-    # openjpeg, giflib, zlib) are not referenced by tesseract's own build --
-    # leptonica handles them and carries them via run_exports -- so they don't
-    # belong here.
+    # tesseract links libtiff directly on Windows (see commit message for the
+    # find_package(TIFF) / WIN32 detail); other imaging codecs come via leptonica.
     - libtiff {{ libtiff }}  # [win]
   run:
     - libgomp  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,13 +15,6 @@ source:
 
 build:
   number: 0
-  # Windows builds with cmake + Ninja + MSVC (SW_BUILD=OFF). Upstream dropped the
-  # old Software Network (SW) client dependency in 5.5.x, which was the historical
-  # blocker. See recipe/bld.bat. (PKG-13890 win enablement; unblocks PKG-13803.)
-  #
-  # TEMPORARY: skip everything except Windows while we iterate on the Windows
-  # build. REMOVE THIS LINE before merge so linux/osx keep building. (PKG-13890)
-  skip: true  # [not win]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x.x') }}
 
@@ -32,11 +25,10 @@ requirements:
     - {{ compiler('cxx') }}  # upstream builds with GCC 14 on Ubuntu 24.04 as of 5.5.2
     - autoconf  # [not win]
     - automake  # [not win]
+    - libtool  # [not win]
+    - make  # [not win]
     - cmake >=3.30  # [win]  # upstream bumped cmake requirement in 5.3+
     - ninja  # [win]
-    - libtool  # [not win]
-    # make is needed for bootstrapping makefile fragments for automatic dependency tracking
-    - make  # [not win]
     - pkg-config
   host:
     - leptonica {{ leptonica }}
@@ -46,8 +38,6 @@ requirements:
     # openmp changes to gcc14 ... [then we can] put it in the cbc or use the
     # c_compiler_version jinja, but that's not available yet.
     - libgomp  # [linux] # analint: host_section_needs_exact_pinnings
-    # tesseract links libtiff directly on Windows (see commit message for the
-    # find_package(TIFF) / WIN32 detail); other imaging codecs come via leptonica.
     - libtiff {{ libtiff }}  # [win]
   run:
     - libgomp  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,10 @@ build:
   # Windows builds with cmake + Ninja + MSVC (SW_BUILD=OFF). Upstream dropped the
   # old Software Network (SW) client dependency in 5.5.x, which was the historical
   # blocker. See recipe/bld.bat. (PKG-13890 win enablement; unblocks PKG-13803.)
+  #
+  # TEMPORARY: skip everything except Windows while we iterate on the Windows
+  # build. REMOVE THIS LINE before merge so linux/osx keep building. (PKG-13890)
+  skip: true  # [not win]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x.x') }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,17 +46,15 @@ requirements:
     # openmp changes to gcc14 ... [then we can] put it in the cbc or use the
     # c_compiler_version jinja, but that's not available yet.
     - libgomp  # [linux] # analint: host_section_needs_exact_pinnings
-    # Imaging deps are pulled in transitively by leptonica, but list them
-    # explicitly on Windows so they're present in the host link environment
-    # (mirrors the conda-forge recipe). libjpeg-turbo is what our channel's
-    # leptonica links against on win-64.
-    - giflib  # [win]
-    - libjpeg-turbo  # [win]
-    - libpng  # [win]
-    - libtiff  # [win]
-    - libwebp  # [win]
-    - openjpeg  # [win]
-    - zlib  # [win]
+    # tesseract's CMake links libtiff directly on Windows for multi-page TIFF
+    # support: find_package(TIFF) + target_link_libraries guarded by
+    # `if(HAVE_TIFFIO_H AND WIN32)`. So it's a direct build dep on win (needs
+    # tiffio.h at configure time + the import lib at link time), not just a
+    # transitive leptonica dep. The other imaging codecs (png, jpeg, webp,
+    # openjpeg, giflib, zlib) are not referenced by tesseract's own build --
+    # leptonica handles them and carries them via run_exports -- so they don't
+    # belong here.
+    - libtiff {{ libtiff }}  # [win]
   run:
     - libgomp  # [linux]
 


### PR DESCRIPTION
## What

Enables the Windows (win-64) build for tesseract, skipped since the recipe was forked from conda-forge.

Upstream dropped the old Software Network (SW) client dependency in 5.5.x — the historical Windows blocker — and now builds with cmake + Ninja + MSVC (`SW_BUILD=OFF`), with a working upstream CI workflow (`cmake-win64.yml`).

Unblocks **PKG-13803** (pytesseract Windows). pytesseract is a pure-Python wrapper that shells out to the `tesseract` binary at runtime; its only Windows blocker is the absent win-64 `tesseract`.

## Changes

- **`recipe/meta.yaml`**
  - Remove `skip: true  # [win]`
  - Add `ninja  # [win]` to build requirements
  - Add `libtiff {{ libtiff }}  # [win]` to host — tesseract's CMake links libtiff directly on Windows (`find_package(TIFF)` + `target_link_libraries` guarded by `if(HAVE_TIFFIO_H AND WIN32)`), so it's a direct build dep there, not just a transitive leptonica dep. The other imaging codecs (png, jpeg, webp, openjpeg, giflib, zlib) are not referenced by tesseract's own build — leptonica carries them via run_exports — so they're not listed.
  - Make the OCR test commands cross-platform (`type`/`fc` on Windows)
  - **TEMP:** `skip: true  # [not win]` so this PR only exercises win-64 while iterating. **Remove before merge** so linux/osx keep building.
- **`recipe/bld.bat`**
  - `NMake Makefiles` → `Ninja` generator (matches conda-forge + upstream)
  - Fix the unversioned-lib copy: 5.5.2 produces `tesseract55.lib` (major+minor from CMake `OUTPUT_NAME`), **not** the old `tesseract41.lib` the inherited script hardcoded
  - Move installed `tessdata/configs` across the `Library` split to the `TESSDATA_PREFIX` location
  - Add `errorlevel` checks after the copy/move steps

## CI status (prior identical branch)

win-64 Build + Test + Aggregation all passed green. This confirms the three things that could only be verified by a real build: the `configs` install path, no `fc` line-ending false positive, and the `tesseract55.lib` name. Linter pinning errors are resolved by pinning `libtiff` to its CBC value.

## Before merge

- [ ] Remove the temporary `skip: true  # [not win]`
- [ ] Confirm linux/osx still build after removing it

🤖 Generated with [Claude Code](https://claude.com/claude-code)